### PR TITLE
Add cli flag `--version` to show version of spanner-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ spanner:
       --directed-read=         Directed read option (replica_location:replica_type). The replicat_type is optional and either READ_ONLY or READ_WRITE
       --skip-tls-verify        Insecurely skip TLS verify
       --proto-descriptor-file= Path of a file that contains a protobuf-serialized google.protobuf.FileDescriptorSet message to use in this invocation.
+      --version                Show version of spanner-cli
 
 Help Options:
   -h, --help                   Show this help message

--- a/main.go
+++ b/main.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"os/user"
 	"path/filepath"
+	"runtime/debug"
 
 	pb "cloud.google.com/go/spanner/apiv1/spannerpb"
 	flags "github.com/jessevdk/go-flags"
@@ -49,6 +50,7 @@ type spannerOptions struct {
 	DirectedRead        string `long:"directed-read" description:"Directed read option (replica_location:replica_type). The replicat_type is optional and either READ_ONLY or READ_WRITE"`
 	SkipTLSVerify       bool   `long:"skip-tls-verify" description:"Insecurely skip TLS verify"`
 	ProtoDescriptorFile string `long:"proto-descriptor-file" description:"Path of a file that contains a protobuf-serialized google.protobuf.FileDescriptorSet message to use in this invocation."`
+	Version             bool   `long:"version" description:"Show version of spanner-cli"`
 }
 
 func main() {
@@ -62,6 +64,11 @@ func main() {
 	// use another parser to process environment variable
 	if _, err := flags.NewParser(&gopts, flags.Default).Parse(); err != nil {
 		exitf("Invalid options\n")
+	}
+
+	if gopts.Spanner.Version {
+		fmt.Fprintf(os.Stdout, "%s\n", versionInfo())
+		os.Exit(0)
 	}
 
 	opts := gopts.Spanner
@@ -196,4 +203,12 @@ func readStdin() (string, error) {
 	} else {
 		return "", nil
 	}
+}
+
+func versionInfo() string {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return "(devel)"
+	}
+	return info.Main.Version
 }


### PR DESCRIPTION
Hello. Thank you for maintaining very useful cli for spanner!

## What
SSIA

## Why
It is more useful for troubleshooting if spanner-cli can show its version.

## Implementation
I intentionally added `Version` to `spannerOptions`, though it might be not good idea to do so because it seems that `--version` is not a option to execute spanner-cli, but a kind of sub-command.

The reason why I did so is that I feel it is difficult to show description of `--version` if I don't add `Version` to `spannerOptions`.

As an alternative, I considered to parse `os.Args` like below, as I mentioned above, it it difficult to show description of `--version` when `spanner-cli --help` is executed.

```go
	if len(os.Args) == 2 && os.Args[1] == "--version" {
		fmt.Fprintf(os.Stdout, "%s\n", versionInfo())
		os.Exit(0)
	}
```

Please give me your opinion.